### PR TITLE
Add QR-based fast inventory web app (index.html) with continuous scan, modal capture, and CSV/mail export

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventario QR Rápido</title>
+  <style>
+    body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:0;background:#111;color:#fff}
+    header{padding:12px 14px;background:#1b1b1b;position:sticky;top:0;z-index:10}
+    .wrap{padding:12px;display:grid;gap:10px;padding-bottom:96px}
+    input,button{font-size:18px;padding:12px;border-radius:10px;border:1px solid #333}
+    input{width:100%;background:#0b0b0b;color:#fff}
+    button{background:#2b6cff;color:#fff;border:none;font-weight:900;cursor:pointer}
+    button.secondary{background:#333}
+    .card{background:#1b1b1b;border:1px solid #2a2a2a;border-radius:14px;padding:12px}
+    .muted{color:#bbb}
+    .row{display:flex;gap:10px;flex-wrap:wrap}
+    .row>*{flex:1;min-width:140px}
+    .status{font-size:14px;color:#bbb;margin-top:10px}
+    .scanBig{font-size:22px;padding:16px;border-radius:14px}
+    .hint{font-size:12px;color:#9a9a9a}
+    .pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#0b0b0b;border:1px solid #2a2a2a;color:#bbb;font-size:12px}
+
+    #reader{width:100%;border-radius:14px;overflow:hidden}
+    table{width:100%;border-collapse:collapse;font-size:14px}
+    th,td{border-bottom:1px solid #2a2a2a;padding:8px;text-align:left}
+    th{color:#bbb;font-weight:700}
+
+    .footerAction{
+      position:fixed;
+      left:12px;
+      right:12px;
+      bottom:14px;
+      z-index:20;
+      border-radius:999px;
+      font-size:20px;
+      box-shadow:0 8px 30px rgba(43,108,255,.35);
+    }
+
+    .modalWrap{
+      position:fixed;inset:0;background:rgba(0,0,0,.65);
+      display:none;align-items:center;justify-content:center;padding:16px;z-index:30;
+    }
+    .modal{
+      width:min(520px,100%);
+      background:#1b1b1b;border:1px solid #2a2a2a;border-radius:16px;padding:14px;
+      display:grid;gap:10px;
+    }
+    .modal h3{margin:0 0 4px 0}
+  </style>
+</head>
+<body>
+  <header>
+    <strong>Inventario QR Rápido</strong>
+    <div class="muted">Escaneo continuo + registro inmediato</div>
+  </header>
+
+  <main class="wrap">
+    <section class="card">
+      <div class="row" style="align-items:center;">
+        <span class="pill" id="scanState">Escáner iniciando…</span>
+        <span class="pill">Registros: <strong id="totalRegistros">0</strong></span>
+      </div>
+      <p class="hint">El lector permanece abierto. Al detectar un QR, se abre un formulario para completar cantidad y número de serie.</p>
+      <div id="reader"></div>
+      <div class="status" id="status">Preparando cámara…</div>
+    </section>
+
+    <section class="card">
+      <h3 style="margin-top:0">Tabla temporal</h3>
+      <div style="overflow:auto;">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Código componente</th>
+              <th>Cantidad</th>
+              <th>Nº serie destino</th>
+              <th>Fecha/hora</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <button class="footerAction" id="mailBtn">📧 Enviar inventario por mail</button>
+
+  <div class="modalWrap" id="modalWrap" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true">
+      <h3>Registrar material escaneado</h3>
+      <div class="muted" id="codigoDetectado"></div>
+      <label>
+        Cantidad
+        <input id="cantidadInput" type="number" min="1" step="1" placeholder="Ej. 10" />
+      </label>
+      <label>
+        Nº de serie destino
+        <input id="serieInput" type="text" placeholder="Ej. SN-2026-001" />
+      </label>
+      <div class="row">
+        <button class="secondary" id="cancelBtn" type="button">Cancelar</button>
+        <button id="guardarBtn" type="button">Registrar</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/html5-qrcode" defer></script>
+  <script>
+    const registros = [];
+    let ultimoCodigo = '';
+    let ultimoMomento = 0;
+    let codigoPendiente = null;
+    let modalAbierta = false;
+
+    const $ = (id) => document.getElementById(id);
+    const tbody = $('tbody');
+    const totalRegistros = $('totalRegistros');
+    const statusEl = $('status');
+    const scanState = $('scanState');
+
+    function fmtDate(d) {
+      return new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'medium' }).format(d);
+    }
+
+    function actualizarTabla() {
+      tbody.innerHTML = '';
+      registros.forEach((r, i) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${i + 1}</td>
+          <td>${r.codigo}</td>
+          <td>${r.cantidad}</td>
+          <td>${r.serie}</td>
+          <td>${r.fecha}</td>
+        `;
+        tbody.appendChild(tr);
+      });
+      totalRegistros.textContent = registros.length;
+    }
+
+    function abrirModal(codigo) {
+      modalAbierta = true;
+      codigoPendiente = codigo;
+      $('codigoDetectado').textContent = `Código detectado: ${codigo}`;
+      $('cantidadInput').value = '';
+      $('serieInput').value = '';
+      $('modalWrap').style.display = 'flex';
+      $('modalWrap').setAttribute('aria-hidden', 'false');
+      $('cantidadInput').focus();
+    }
+
+    function cerrarModal() {
+      modalAbierta = false;
+      codigoPendiente = null;
+      $('modalWrap').style.display = 'none';
+      $('modalWrap').setAttribute('aria-hidden', 'true');
+      statusEl.textContent = 'Escáner activo. Esperando siguiente QR…';
+    }
+
+    $('cancelBtn').addEventListener('click', cerrarModal);
+
+    $('guardarBtn').addEventListener('click', () => {
+      const cantidad = Number($('cantidadInput').value);
+      const serie = $('serieInput').value.trim();
+
+      if (!codigoPendiente) return;
+      if (!cantidad || cantidad <= 0) {
+        alert('Introduce una cantidad válida mayor que 0.');
+        return;
+      }
+      if (!serie) {
+        alert('Introduce el número de serie destino.');
+        return;
+      }
+
+      registros.push({
+        codigo: codigoPendiente,
+        cantidad,
+        serie,
+        fecha: fmtDate(new Date())
+      });
+
+      actualizarTabla();
+      cerrarModal();
+    });
+
+    function generarCSV() {
+      const encabezado = ['codigo_componente', 'cantidad', 'numero_serie_destino', 'fecha_hora'];
+      const filas = registros.map(r => [r.codigo, r.cantidad, r.serie, r.fecha]);
+      return [encabezado, ...filas]
+        .map(row => row.map(v => `"${String(v).replaceAll('"', '""')}"`).join(';'))
+        .join('\n');
+    }
+
+    function descargarCSV(nombre, contenido) {
+      const blob = new Blob([contenido], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = nombre;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    $('mailBtn').addEventListener('click', () => {
+      if (!registros.length) {
+        alert('No hay registros todavía.');
+        return;
+      }
+
+      const csv = generarCSV();
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      descargarCSV(`inventario-${stamp}.csv`, csv);
+
+      const asunto = encodeURIComponent(`Inventario QR (${registros.length} registros)`);
+      const cuerpo = encodeURIComponent(
+        'Adjunta el CSV descargado automáticamente con los registros del inventario.\n\n' +
+        'Vista rápida:\n' + csv.slice(0, 1200)
+      );
+
+      window.location.href = `mailto:?subject=${asunto}&body=${cuerpo}`;
+    });
+
+    function onScanSuccess(decodedText) {
+      const ahora = Date.now();
+      const duplicadoReciente = decodedText === ultimoCodigo && (ahora - ultimoMomento) < 2500;
+      if (modalAbierta || duplicadoReciente) return;
+
+      ultimoCodigo = decodedText;
+      ultimoMomento = ahora;
+      statusEl.textContent = `QR detectado: ${decodedText}`;
+      abrirModal(decodedText);
+    }
+
+    async function iniciarScanner() {
+      try {
+        const html5QrCode = new Html5Qrcode('reader');
+        const cams = await Html5Qrcode.getCameras();
+        if (!cams?.length) throw new Error('No se detectaron cámaras.');
+
+        await html5QrCode.start(
+          { facingMode: 'environment' },
+          { fps: 10, qrbox: { width: 240, height: 240 } },
+          onScanSuccess,
+          () => {}
+        );
+
+        scanState.textContent = 'Escáner activo';
+        statusEl.textContent = 'Escáner activo. Esperando primer QR…';
+      } catch (err) {
+        scanState.textContent = 'Error de cámara';
+        statusEl.textContent = `No se pudo abrir la cámara: ${err.message || err}`;
+      }
+    }
+
+    window.addEventListener('load', iniciarScanner);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Proveer una app web móvil ligera para hacer inventarios rápidos leyendo códigos QR de forma continua sin tomar fotos y pidiendo cantidad y número de serie inmediatamente tras cada escaneo.
- Mantener la experiencia visual y los estilos usados en el resto de las apps para coherencia de UI.

### Description
- Añadido `index.html` que implementa una SPA móvil-friendly con el estilo oscuro proporcionado y estructura de cabecera, área de escáner, tabla temporal y botón de acción inferior redondeado.
- Integrado `html5-qrcode` para escaneo continuo con cámara trasera y control anti-duplicado (throttle) para evitar lecturas repetidas en pocos segundos.
- Añadido flujo modal que aparece tras cada lectura para introducir `cantidad` y `nº de serie destino`, validar campos y guardar la fila en una tabla temporal en memoria con marca de fecha/hora.
- Implementada exportación: generación de CSV, descarga automática y apertura de `mailto:` con asunto/cuerpo prellenados para facilitar el envío del inventario.

### Testing
- Ejecutado `git add index.html && git commit -m "Add QR inventory web app with continuous scan and email export"` y la operación de commit completó correctamente.
- Ejecutado `git status --short` para verificar el estado y no quedan cambios pendientes, y este chequeo fue exitoso.
- Intentado servir la carpeta con `python3 -m http.server 4173 --directory /workspace/markosdg2000-design.github.io` y probar con `curl -I http://127.0.0.1:4173`, pero la conexión al servidor local falló en este entorno de ejecución y no se pudo completar la previsualización automática.
- Intentado capturar una captura con Playwright (`mcp__browser_tools__run_playwright_script`) para verificar renderizado y la operación falló con `net::ERR_EMPTY_RESPONSE` debido a la limitación de acceso al servidor en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a6650c88832093741af342d8de77)